### PR TITLE
Removed remnant of optimization testing

### DIFF
--- a/app/libs/lif.py
+++ b/app/libs/lif.py
@@ -34,8 +34,7 @@ class Lif:
     def suggest(self):
 
         if np.all(np.isfinite(self.theta['Yw'][:,0])):
-            self.theta['x0'] = np.mean(self.theta['Yw'][:,1])
-            self.theta['x0'] = self.theta['x0'] + self.gamma * sum( self.theta['Yw'][:,2] )
+            self.theta['x0'] = self.theta['x0'] + self.gamma * sum( self.theta['Yw'][:,2] ) / self.T
             if self.lifversion==1: self.theta['Yw'].fill(np.nan)
 
         self.theta['t'] = self.theta['t'] + 1


### PR DESCRIPTION
Removal of superfluous remnant of previous experimentation with rolling averages.
Code now conform to Kaptein, Maurits, and Davide Iannuzzi. "Lock in Feedback in Sequential Experiments." arXiv preprint arXiv:1502.00598 (2015) again.
