### PR TITLE
remove unneeded _pickle module which causes failure

### DIFF
--- a/app/handlers/evalhandlers.py
+++ b/app/handlers/evalhandlers.py
@@ -9,7 +9,6 @@ import time
 import contextlib
 
 from bson.binary import Binary
-import _pickle
 
 from handlers.basehandler import BaseHandler, ExceptionHandler
 from core.experiment import Experiment


### PR DESCRIPTION
This import causes an `ImportError: No module named '_pickle'`.

Is this import necessary (if so seems should use `pickle` not `_pickle`

Also there seem to be a bunch of unused imports in the various handler files.  Are these needed?