### PR TITLE
Fix configs for docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,6 @@ RUN pip install --upgrade pip
 
 #CMD python3 ./insert_admin.py --password ${PASS}
 
-RUN sed -i -e 's/redis_ip : localhost/redis_ip : redis/g' ./app/config.cfg
-RUN sed -i -e 's/mongo_ip : localhost/mongo_ip : mongo/g' ./app/config.cfg
-
 RUN pip install .
 
 WORKDIR /sb/app/

--- a/app/app.py
+++ b/app/app.py
@@ -27,7 +27,7 @@ import builtins
 
 dir = os.path.dirname(__file__)
 f = open(os.path.join(dir,'config.cfg'),'r')
-settings = yaml.load(f)
+settings = yaml.load(f, Loader=yaml.FullLoader)
 f.close()
         
 ########## Logging ##########

--- a/app/app.py
+++ b/app/app.py
@@ -27,9 +27,11 @@ import builtins
 
 dir = os.path.dirname(__file__)
 f = open(os.path.join(dir,'config.cfg'),'r')
-settings = yaml.load(f, Loader=yaml.FullLoader)
+env=os.getenv('env', 'default')
+config = yaml.load(f, Loader=yaml.FullLoader)
+settings = config[env]
 f.close()
-        
+
 ########## Logging ##########
 formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 

--- a/app/config.cfg
+++ b/app/config.cfg
@@ -1,13 +1,21 @@
 --- # Set IP for Redis server, default is localhost
-redis_ip : localhost
-redis_port : 6379
-mongo_ip : localhost
-mongo_port : 27017
+default: &default
+    redis_ip : localhost
+    redis_port : 6379
+    mongo_ip : localhost
+    mongo_port : 27017
 
-listen.port : 8080
+    listen.port : 8080
 
-log.level: 10
-log.console.level : 4
-log.access : access.log
-log.app : app.log
-log.general : general.log
+    log.level: 10
+    log.console.level : 4
+    log.access : access.log
+    log.app : app.log
+    log.general : general.log
+
+
+docker:
+    <<: *default
+    # these should match labels assigned in docker-compose.yml
+    redis_ip : redis
+    mongo_ip : mongo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,3 +8,5 @@ services:
     build: .
     ports:
      - "8080:8080"
+    environment:
+      - env=docker


### PR DESCRIPTION
i wasn't able to get the app running thru docker-compose because the `redis_ip` and `mongo_ip` settings were not getting changed from `localhost` -- i assume this is what the `sed` statements in the `Dockerfile` were supposed to do, but they didn't work for me.

this PR fixes that problem by using a more standard yaml approach which i think is more flexible and scalable were one to extend to additional environments

