### PR TITLE
Ensure action is not set prior to summary step

### DIFF
--- a/app/handlers/corehandlers.py
+++ b/app/handlers/corehandlers.py
@@ -36,7 +36,7 @@ class ActionHandler(tornado.web.RequestHandler):
         __EXP__ = Experiment(exp_id, key)
         
         if __EXP__.is_valid():
-            response = __EXP__.run_action_code(context)
+            response = __EXP__.run_action_code(context, {})
             
             if __EXP__.properties['advice_id'] == "True":
                 advice_id = __EXP__.gen_advice_id(response.copy(), context.copy())


### PR DESCRIPTION
I've run into an issue where action keys specific to an experiment can appear in others. To remedy this, we can enforce that the action variable is not set prior to the experiment executing its getaction summary step.

Example with `__EXP__.run_action_code(context)`:
```python
# action response from Experiment "A"
Action A: {'action': {'shouldNotExistInExperimentB': 'Error!', 'treatment': 'control', 'experiment': 'A', 'propensity': 0.9}, 'context': {}, 'advice_id': '5dfe3dd4a7f16bfa6007e2f8'}

# action response from Experiment "B"
Action B: {'action': {'shouldNotExistInExperimentB': 'Error!', 'treatment': 'treatment', 'experiment': 'B', 'propensity': 0.5}, 'context': {}, 'advice_id': '5dfe3dd4a7f16bfa6007e2fa'}
```

Example with `__EXP__.run_action_code(context, {})`:
```python
# action response from Experiment "A"
Action A: {'context': {}, 'action': {'treatment': 'control', 'propensity': 0.9, 'shouldNotExistInExperimentB': 'Error!', 'experiment': 'A'}, 'advice_id': '5dfe3e696dd836a9673e715b'}

# fixed action response from Experiment "B"
Action B: {'context': {}, 'action': {'treatment': 'control', 'propensity': 0.5, 'experiment': 'B'}, 'advice_id': '5dfe3e696dd836a9673e715d'}
```

EDIT: However, this does appear to be a hot-fix since the larger issue seems to be that `self.action` is being shared between different experiments. This could be a consequence of how `self` is being handled in `experiment.py`.