### PR TITLE
Delete corresponding advice_ids after an experiment is reset.

### DIFF
--- a/app/core/experiment.py
+++ b/app/core/experiment.py
@@ -315,5 +315,11 @@ class Experiment():
     def get_by_advice_id(self, _id):
         return self.advice_db.get_advice(self.exp_id, _id)
 
+    def delete_all_advice_ids(self):
+        if self.properties["advice_id"] == "True":
+            return self.advice_db.delete_all_advice_ids(self.exp_id)
+        else:
+            return None
+
     def debug(self, obj):
         self.context['_debug'] = obj

--- a/app/db/advice.py
+++ b/app/db/advice.py
@@ -30,3 +30,7 @@ class Advice:
             return {'context': context, 'action': action}
         else:
             return False
+
+    def delete_all_advice_ids(self, exp_id):
+        result = self.advices.delete_many({"exp_id": exp_id})
+        return result

--- a/app/handlers/adminhandlers.py
+++ b/app/handlers/adminhandlers.py
@@ -333,20 +333,22 @@ class ResetExperiment(BaseHandler):
         """
         if self.get_secure_cookie("user"):
             if self.validate_user_experiment(exp_id):
-                key = self.get_argument("key", default = False)
-                theta_key = self.get_argument("theta_key", default = None)
-                theta_value = self.get_argument("theta_value", default = None)
+                key = self.get_argument("key", default=False)
+                theta_key = self.get_argument("theta_key", default=None)
+                theta_value = self.get_argument("theta_value", default=None)
                 __EXP__ = Experiment(exp_id, key)
-
-                status = __EXP__.delete_theta(key = theta_key, value = theta_value)
+                status = __EXP__.delete_theta(key=theta_key, value=theta_value)
+                if __EXP__.properties["advice_id"] == "True":
+                    if (theta_key is None) and (theta_value is None):
+                        __EXP__.delete_all_advice_ids()
                 if status >= 1:
-                    self.write(json.dumps({'status':'success'}))
+                    self.write(json.dumps({"status": "success"}))
                 else:
-                    raise ExceptionHandler(reason = "Theta_key or theta_value could not be validated.", status_code = 401)
+                    raise ExceptionHandler(reason="Theta_key or theta_value could not be validated.", status_code=401)
             else:
-                raise ExceptionHandler(reason = "Experiment could not be validated.", status_code = 401)
+                raise ExceptionHandler(reason="Experiment could not be validated.", status_code=401)
         else:
-            raise ExceptionHandler(reason = "Could not validate user.", status_code = 401)
+            raise ExceptionHandler(reason="Could not validate user.", status_code=401)
 
 class AddUser(BaseHandler):
 


### PR DESCRIPTION
This fix is related to the following issue: https://github.com/Nth-iteration-labs/streamingbandit/issues/90

The current implementation will clear advice_ids associated with a given exp_id after the ResetExperiment endpoint is triggered. As of now, advice_ids will only be cleared from the advices collection if no theta key-value pair is specified, i.e. the experimenter wants to reset all theta objects.