### PR TITLE
base.List refactor

### DIFF
--- a/app/libs/base.py
+++ b/app/libs/base.py
@@ -342,6 +342,7 @@ class List:
 
     def __init__(self, objects, _t, value_names):
         self.value_names = value_names
+        self.num_values = len(self.value_names)
         self.base_list = {value_name: _t(objects.get(value_name, {})) for value_name in self.value_names}
         self.size = len(self.base_list)
     

--- a/app/libs/base.py
+++ b/app/libs/base.py
@@ -329,7 +329,7 @@ class Correlation(__strmBase):
         else:
             raise ValueError("Correlation should be between -1 and +1!")
 
-class List():
+class List:
     """ Class to represent a list of Base classes. Here you can store multiple \
     Base classes to simplify your AB test and whatnot.
 
@@ -341,56 +341,34 @@ class List():
     """
 
     def __init__(self, objects, _t, value_names):
-        self.base_list = {}
         self.value_names = value_names
-        self.num_values = len(self.value_names)
-        if objects == {}:
-            for value_name in self.value_names:
-                self.base_list[value_name] = _t(default={})
-        elif len(objects) < len(self.value_names):
-            for key, obj in objects.items():
-                self.base_list[key] = _t(default=obj)
-            for val in self.value_names:
-                if val not in self.base_list:
-                    self.base_list[val] = _t(default={})
-        else:
-            for key, obj in objects.items():
-                self.base_list[key] = _t(default=obj)
+        self.base_list = {value_name: _t(objects.get(value_name, {})) for value_name in self.value_names}
         self.size = len(self.base_list)
     
     def get_dict(self):
         """ Returns each Base class in the objects as a dict in a dict.
         """
-        dict_list = {}
-        for key, val in self.base_list.items():
-            dict_list[key] = val.get_dict()
-        return dict_list
+        return {k: v.get_dict() for k, v in self.base_list.items()}
+
+    def get_value(self):
+        return {k: v.get_value() for k, v in self.base_list.items()}
 
     def max(self):
         """ Finds the max of the main value of a Base class.
         If no max is available yet (because the values are empty), it will return a random max.
         """
-        max_val = 0
-        max_key = ""
-        for key, value in self.base_list.items():
-            if value.get_value() > max_val:
-                max_key = key
-                max_val = value.get_value()
-        if max_key == "":
-            max_key = self.random()
-        return max_key
+        d = self.get_value()
+        max_key = max(d, key=d.get)
+        if d[max_key] == 0:
+            return self.random()
+        else:
+            return max_key
 
     def count(self):
         """ Checks if the Base class has a counter. If that's the case, it will
         add all the counters and return the total count.
         """
-        count = 0
-        for key, value in self.base_list.items():
-            values = value.get_dict()
-            if 'n' not in values:
-                break
-            count = count + int(values['n'])
-        return count
+        return int(sum(v.get_dict().get("n", 0) for v in self.base_list.values()))
 
     def random(self):
         """ Return a random choice from the value_names list.

--- a/app/libs/base.py
+++ b/app/libs/base.py
@@ -336,7 +336,7 @@ class List:
     :var dict objects: A dict of dicts with the objects in dictionary \
             form - so not a class instance!
     :var type _t: The type of Base class (e.g. Proportion, Count).
-    :var list value_names: The different value names that are in the \
+    :var list value_names: The value names to be grabbed from the \
             objects dict. This is used for e.g. random picks.
     """
 
@@ -352,11 +352,13 @@ class List:
         return {k: v.get_dict() for k, v in self.base_list.items()}
 
     def get_value(self):
+        """ Returns the main value of each Base class in the objects in a dict.
+        """
         return {k: v.get_value() for k, v in self.base_list.items()}
 
     def max(self):
-        """ Finds the max of the main value of a Base class.
-        If no max is available yet (because the values are empty), it will return a random max.
+        """ Finds the maximum main value from all Base classes.
+        If no max is available yet (because all main values are 0), it will return a random max.
         """
         d = self.get_value()
         max_key = max(d, key=d.get)

--- a/app/libs/base.py
+++ b/app/libs/base.py
@@ -368,7 +368,11 @@ class List:
         """ Checks if the Base class has a counter. If that's the case, it will
         add all the counters and return the total count.
         """
-        return int(sum(v.get_dict().get("n", 0) for v in self.base_list.values()))
+        for v in self.base_list.values():
+            if "n" not in v.get_dict():
+                return 0 
+            else:
+                return int(sum(v.get_dict().get("n") for v in self.base_list.values()))
 
     def random(self):
         """ Return a random choice from the value_names list.


### PR DESCRIPTION
There was an issue with how the `self.base_list` dict was being formed  where we weren't ensuring that only the value_names provided were being used from the theta objects during the decision-making process.

Consider the following example:
```python
# get a set of variations stored in Redis that the experimenter can dynamically update
variants = self.get_variations(key="myVariants") # initially returns ["A", "B"]
theta = self.get_theta(key="x") # initially returns {}
mean_list = base.List(theta, base.Mean, variants) # base_list keys return ["A", "B"]
```

The above behaves as expected, however, if the experimenter decides that they no longer want to use variation "B" anymore and they replace it with variation "C", the following would happen:
```python
# get a set of variations stored in Redis that the experimenter can dynamically update
variants = self.get_variations(key="myVariants") # now returns ["A", "C"]
theta = self.get_theta(key="x") # now returns {"x:A": {"m": 10, "n": 10}, "x:B": {"m": 30, "n": 25}}
mean_list = base.List(theta, base.Mean, variants) # base_list keys return ["A", "B", "C"]
```

The keys considered in `mean_list.base_list` should actually just be `["A", "C"]`. Variation "B" still exists within theta, we just want to make sure that the `base.List` only considers the keys / value_names passed to it rather than all of the theta object keys ever used.

There are also some other edits made to the class methods `max`, `count` and `get_dict` to help clean things up a bit. I also added a `get_value()` method that the new `max` method uses that might be useful in some other cases.